### PR TITLE
Do not reply GENERIC_NACK when receiving an unknown response.

### DIFF
--- a/src/gen_esme_session.erl
+++ b/src/gen_esme_session.erl
@@ -451,10 +451,6 @@ handle_event({input, CmdId, Pdu, _Lapse, _Timestamp}, Stn, Std)
                     {next_state, Stn, Std}
             end;
         {error, not_found} ->
-            Sock = Std#st.sock,
-            Log = Std#st.log,
-            Nack = ?COMMAND_ID_GENERIC_NACK,
-            send_response(Nack, ?ESME_RINVCMDID, SeqNum, [], Sock, Log),
             {next_state, Stn, Std}
     end;
 handle_event({input, CmdId, Pdu, _Lapse, _Timestamp}, Stn, Std)


### PR DESCRIPTION
We have detected that if the SMSC replies to a request that has timed out in our side, we will send a GENERIC NACK pdu that might cause the SMSC to stop replying further requests.